### PR TITLE
Add Express backend with SQLite migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-"node_modules/" 
+node_modules/
+backend/data.sqlite3

--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -1,0 +1,12 @@
+module.exports = {
+  development: {
+    client: 'sqlite3',
+    connection: {
+      filename: './data.sqlite3'
+    },
+    useNullAsDefault: true,
+    migrations: {
+      directory: './migrations'
+    }
+  }
+};

--- a/backend/migrations/20240202000000_init.js
+++ b/backend/migrations/20240202000000_init.js
@@ -1,0 +1,45 @@
+exports.up = async function(knex) {
+  await knex.schema.createTable('students', (table) => {
+    table.increments('id').primary();
+    table.string('name').notNullable();
+    table.string('email').notNullable().unique();
+    table.string('password').notNullable();
+  });
+
+  await knex.schema.createTable('companies', (table) => {
+    table.increments('id').primary();
+    table.string('name').notNullable();
+    table.string('email').notNullable().unique();
+    table.string('password').notNullable();
+  });
+
+  await knex.schema.createTable('internships', (table) => {
+    table.increments('id').primary();
+    table.integer('company_id').references('id').inTable('companies');
+    table.string('title').notNullable();
+    table.text('description');
+  });
+
+  await knex.schema.createTable('student_profiles', (table) => {
+    table.increments('id').primary();
+    table.integer('student_id').references('id').inTable('students');
+    table.string('major');
+    table.integer('year');
+    table.text('resume');
+  });
+
+  await knex.schema.createTable('allocations', (table) => {
+    table.increments('id').primary();
+    table.integer('student_id').references('id').inTable('students');
+    table.integer('internship_id').references('id').inTable('internships');
+    table.unique(['student_id', 'internship_id']);
+  });
+};
+
+exports.down = async function(knex) {
+  await knex.schema.dropTableIfExists('allocations');
+  await knex.schema.dropTableIfExists('student_profiles');
+  await knex.schema.dropTableIfExists('internships');
+  await knex.schema.dropTableIfExists('companies');
+  await knex.schema.dropTableIfExists('students');
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "sih-backend",
+  "version": "1.0.0",
+  "main": "src/app.js",
+  "scripts": {
+    "dev": "node src/app.js",
+    "migrate": "knex migrate:latest",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "knex": "^2.5.1",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const authRoutes = require('./routes/auth');
+const studentRoutes = require('./routes/students');
+const internshipRoutes = require('./routes/internships');
+const allocationRoutes = require('./routes/allocations');
+
+const app = express();
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+app.use('/students', studentRoutes);
+app.use('/internships', internshipRoutes);
+app.use('/allocations', allocationRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+
+module.exports = app;

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,0 +1,4 @@
+const knex = require('knex');
+const config = require('../knexfile');
+const env = process.env.NODE_ENV || 'development';
+module.exports = knex(config[env]);

--- a/backend/src/routes/allocations.js
+++ b/backend/src/routes/allocations.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const db = require('../db');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { student_id, internship_id } = req.body;
+  try {
+    const [id] = await db('allocations').insert({ student_id, internship_id });
+    res.json({ id });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.get('/', async (req, res) => {
+  const allocations = await db('allocations');
+  res.json(allocations);
+});
+
+module.exports = router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const db = require('../db');
+
+const router = express.Router();
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+router.post('/students/register', async (req, res) => {
+  const { name, email, password } = req.body;
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const [id] = await db('students').insert({ name, email, password: hashed });
+    res.json({ id });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/students/login', async (req, res) => {
+  const { email, password } = req.body;
+  const student = await db('students').where({ email }).first();
+  if (!student) return res.status(400).json({ error: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, student.password);
+  if (!valid) return res.status(400).json({ error: 'Invalid credentials' });
+  const token = jwt.sign({ id: student.id, type: 'student' }, SECRET);
+  res.json({ token });
+});
+
+router.post('/companies/register', async (req, res) => {
+  const { name, email, password } = req.body;
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const [id] = await db('companies').insert({ name, email, password: hashed });
+    res.json({ id });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/companies/login', async (req, res) => {
+  const { email, password } = req.body;
+  const company = await db('companies').where({ email }).first();
+  if (!company) return res.status(400).json({ error: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, company.password);
+  if (!valid) return res.status(400).json({ error: 'Invalid credentials' });
+  const token = jwt.sign({ id: company.id, type: 'company' }, SECRET);
+  res.json({ token });
+});
+
+module.exports = router;

--- a/backend/src/routes/internships.js
+++ b/backend/src/routes/internships.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const db = require('../db');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const internships = await db('internships');
+  res.json(internships);
+});
+
+router.post('/', async (req, res) => {
+  const { company_id, title, description } = req.body;
+  const [id] = await db('internships').insert({ company_id, title, description });
+  res.json({ id });
+});
+
+router.get('/:id', async (req, res) => {
+  const internship = await db('internships').where({ id: req.params.id }).first();
+  if (!internship) return res.status(404).json({ error: 'Not found' });
+  res.json(internship);
+});
+
+router.put('/:id', async (req, res) => {
+  const { title, description } = req.body;
+  await db('internships').where({ id: req.params.id }).update({ title, description });
+  res.json({ updated: true });
+});
+
+router.delete('/:id', async (req, res) => {
+  await db('internships').where({ id: req.params.id }).del();
+  res.json({ deleted: true });
+});
+
+module.exports = router;

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const db = require('../db');
+
+const router = express.Router();
+
+router.get('/:id/profile', async (req, res) => {
+  const profile = await db('student_profiles').where({ student_id: req.params.id }).first();
+  res.json(profile || {});
+});
+
+router.put('/:id/profile', async (req, res) => {
+  const { major, year, resume } = req.body;
+  const existing = await db('student_profiles').where({ student_id: req.params.id }).first();
+  if (existing) {
+    await db('student_profiles').where({ student_id: req.params.id }).update({ major, year, resume });
+    res.json({ updated: true });
+  } else {
+    await db('student_profiles').insert({ student_id: req.params.id, major, year, resume });
+    res.json({ created: true });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- scaffold Express backend with SQLite configuration
- add auth, profile, internship, and allocation routes
- provide Knex migration for students, companies, internships, profiles, and allocations tables

## Testing
- `npm test` (backend)
- `npm test` (root)
- `npm run migrate` *(fails: knex: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aaaab28c8333941d8c2d202339aa