### PR TITLE
Add testing setup with Vitest and basic portal tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-"node_modules/" 
+node_modules/

--- a/package.json
+++ b/package.json
@@ -50,10 +50,16 @@
       "devDependencies": {
           "@types/node": "^20.10.0",
           "@vitejs/plugin-react-swc": "^3.10.2",
-          "vite": "6.3.5"
+          "vite": "6.3.5",
+          "vitest": "^2.1.1",
+          "@testing-library/react": "^14.2.1",
+          "@testing-library/jest-dom": "^6.4.2",
+          "@testing-library/user-event": "^14.5.1",
+          "jsdom": "^24.1.0"
       },
       "scripts": {
           "dev": "vite",
-          "build": "vite build"
+          "build": "vite build",
+          "test": "vitest"
       }
   }

--- a/tests/allocation.test.tsx
+++ b/tests/allocation.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { StudentPortal } from '../src/components/student-portal';
+
+async function loginAndCreateProfile() {
+  render(<StudentPortal onNavigate={vi.fn()} />);
+  await userEvent.type(screen.getByLabelText(/Email Address/i), 'student@uni.edu');
+  await userEvent.type(screen.getByLabelText(/^Password$/i), 'password');
+  await userEvent.click(screen.getByRole('button', { name: /login to dashboard/i }));
+  await userEvent.type(screen.getByLabelText(/College\/University/i), 'IIT');
+  await userEvent.type(screen.getByLabelText(/Course\/Degree/i), 'B.Tech');
+  await userEvent.type(screen.getByLabelText(/Year of Study/i), '3');
+  await userEvent.type(screen.getByLabelText(/CGPA\/Percentage/i), '8.5');
+  await userEvent.type(screen.getByLabelText(/Skills/i), 'React');
+  await userEvent.click(screen.getByRole('button', { name: /create profile/i }));
+}
+
+describe('Allocation results', () => {
+  it('shows internship allocation after refreshing', async () => {
+    await loginAndCreateProfile();
+    await userEvent.click(screen.getByRole('tab', { name: /My Internship/i }));
+    expect(screen.getByText(/No Internship Allocated/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Refresh Status/i }));
+    expect(await screen.findByText(/Internship Allocated!/i)).toBeInTheDocument();
+  });
+});

--- a/tests/auth.test.tsx
+++ b/tests/auth.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { StudentPortal } from '../src/components/student-portal';
+
+describe('Authentication flows', () => {
+  it('logs in an existing student', async () => {
+    render(<StudentPortal onNavigate={vi.fn()} />);
+    await userEvent.type(screen.getByLabelText(/Email Address/i), 'student@uni.edu');
+    await userEvent.type(screen.getByLabelText(/^Password$/i), 'password');
+    await userEvent.click(screen.getByRole('button', { name: /login to dashboard/i }));
+    expect(await screen.findByText(/Create Your Profile/i)).toBeInTheDocument();
+  });
+
+  it('registers a new student', async () => {
+    render(<StudentPortal onNavigate={vi.fn()} />);
+    await userEvent.click(screen.getByRole('tab', { name: /register/i }));
+    await userEvent.type(screen.getByLabelText(/Full Name/i), 'John Doe');
+    await userEvent.type(screen.getByLabelText(/Email Address/i), 'john@uni.edu');
+    await userEvent.type(screen.getByLabelText(/Phone Number/i), '1234567890');
+    await userEvent.type(screen.getByLabelText(/^Password$/i), 'secret');
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(await screen.findByText(/Create Your Profile/i)).toBeInTheDocument();
+  });
+});

--- a/tests/form-validation.test.tsx
+++ b/tests/form-validation.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { StudentPortal } from '../src/components/student-portal';
+
+describe('Form validation', () => {
+  it('requires email and password for login', async () => {
+    const { container } = render(<StudentPortal onNavigate={vi.fn()} />);
+    const form = container.querySelector('form') as HTMLFormElement;
+    const email = screen.getByLabelText(/Email Address/i) as HTMLInputElement;
+    const password = screen.getByLabelText(/^Password$/i) as HTMLInputElement;
+
+    expect(email).toBeRequired();
+    expect(password).toBeRequired();
+    expect(form.checkValidity()).toBe(false);
+
+    await userEvent.type(email, 'student@uni.edu');
+    await userEvent.type(password, 'password');
+    expect(form.checkValidity()).toBe(true);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,4 +58,9 @@
       port: 3000,
       open: true,
     },
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: './tests/setup.ts',
+    },
   });


### PR DESCRIPTION
## Summary
- configure Vitest and React Testing Library
- add tests for authentication, form validation, and allocation flows
- run tests in CI on each commit

## Testing
- `npm test` (fails: `vitest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_68c5b3d062988333a0ef400be8a1bfe7