### PR TITLE
Use default dist output for Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,7 @@
     },
     build: {
       target: 'esnext',
-      outDir: 'build',
+      outDir: 'dist',
     },
     server: {
       port: 3000,


### PR DESCRIPTION
## Summary
- Update Vite build configuration to emit files into the default `dist` directory

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5b6fa9f48833397897e854b82b146