### PR TITLE
Add student/admin/internship models and schema initialization

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS students (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  name TEXT,
+  major TEXT
+);
+
+CREATE TABLE IF NOT EXISTS admins (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  name TEXT
+);
+
+CREATE TABLE IF NOT EXISTS internships (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  student_id INTEGER NOT NULL,
+  company TEXT NOT NULL,
+  position TEXT NOT NULL,
+  start_date TEXT,
+  end_date TEXT,
+  FOREIGN KEY (student_id) REFERENCES students(id)
+);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
           "vite": "6.3.5"
       },
       "scripts": {
-          "dev": "vite",
-          "build": "vite build"
-      }
+    "dev": "vite",
+    "build": "vite build",
+    "db:init": "sqlite3 database.db < db/schema.sql"
+  }
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,23 @@
+export interface Student {
+  id: number;
+  email: string;
+  password_hash: string;
+  name?: string;
+  major?: string;
+}
+
+export interface Admin {
+  id: number;
+  email: string;
+  password_hash: string;
+  name?: string;
+}
+
+export interface Internship {
+  id: number;
+  student_id: number;
+  company: string;
+  position: string;
+  start_date?: string;
+  end_date?: string;
+}


### PR DESCRIPTION
## Summary
- define Student, Admin, and Internship TypeScript interfaces
- add SQLite schema with tables and relation from students to internships
- add npm script to initialize the database

## Testing
- `npm run db:init && sqlite3 database.db '.tables'`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5bef764608333a1ba86e9052f81a0