### PR TITLE
Add auth and profile endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,11 @@
           "recharts": "^2.15.2",
           "sonner": "^2.0.3",
           "tailwind-merge": "*",
-          "vaul": "^1.1.2"
+          "vaul": "^1.1.2",
+          "bcryptjs": "^2.4.3",
+          "cookie-parser": "^1.4.6",
+          "express": "^4.19.2",
+          "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
           "@types/node": "^20.10.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,90 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const cookieParser = require('cookie-parser');
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+
+const users = [];
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+app.post('/api/auth/register', async (req, res) => {
+  const { username, password, role } = req.body;
+  if (!username || !password || !role) {
+    return res.status(400).json({ message: 'username, password and role are required' });
+  }
+
+  const existing = users.find(u => u.username === username && u.role === role);
+  if (existing) {
+    return res.status(409).json({ message: 'User already exists' });
+  }
+
+  const hashed = await bcrypt.hash(password, 10);
+  const user = {
+    id: users.length + 1,
+    username,
+    password: hashed,
+    role,
+    profile: {}
+  };
+  users.push(user);
+
+  res.status(201).json({ message: 'Registered' });
+});
+
+app.post('/api/auth/login', async (req, res) => {
+  const { username, password, role } = req.body;
+  const user = users.find(u => u.username === username && u.role === role);
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign({ id: user.id, role: user.role }, JWT_SECRET, { expiresIn: '1h' });
+  res.cookie('token', token, { httpOnly: true });
+  res.json({ message: 'Logged in' });
+});
+
+function auth(req, res, next) {
+  const token = req.cookies.token;
+  if (!token) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  try {
+    req.user = jwt.verify(token, JWT_SECRET);
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Unauthorized' });
+  }
+}
+
+app.get('/api/profile', auth, (req, res) => {
+  const user = users.find(u => u.id === req.user.id);
+  if (!user) {
+    return res.status(404).json({ message: 'Not found' });
+  }
+  res.json({ username: user.username, role: user.role, profile: user.profile });
+});
+
+app.put('/api/profile', auth, (req, res) => {
+  const user = users.find(u => u.id === req.user.id);
+  if (!user) {
+    return res.status(404).json({ message: 'Not found' });
+  }
+  user.profile = { ...user.profile, ...req.body };
+  res.json({ message: 'Profile updated', profile: user.profile });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = app;
+


### PR DESCRIPTION
## Summary
- create Express server with registration and login endpoints for students and admins
- hash passwords and issue JWT cookie
- add profile fetch/update routes

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5bef821fc8333876d9c835fa471ed