### PR TITLE
Implement JWT authentication and protected profile endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-"node_modules/" 
+node_modules/
+build/

--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
           "class-variance-authority": "^0.7.1",
           "clsx": "*",
           "cmdk": "^1.1.1",
+          "cookie-parser": "^1.4.6",
           "embla-carousel-react": "^8.6.0",
+          "express": "^4.19.2",
           "input-otp": "^1.4.2",
+          "jsonwebtoken": "^9.0.2",
           "lucide-react": "^0.487.0",
           "next-themes": "^0.4.6",
           "react": "^18.3.1",
@@ -54,6 +57,7 @@
       },
       "scripts": {
           "dev": "vite",
-          "build": "vite build"
+          "build": "vite build",
+          "server": "node server/index.js"
       }
   }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const cookieParser = require('cookie-parser');
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+
+const SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+// Demo users
+const users = [
+  { id: 1, username: 'student@university.edu', password: 'password', profile: { name: 'Student User' } }
+];
+
+// Login endpoint issues JWT
+app.post('/api/auth/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username && u.password === password);
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ id: user.id }, SECRET, { expiresIn: '1h' });
+  res.cookie('token', token, { httpOnly: true });
+  res.json({ token });
+});
+
+// Middleware to verify JWT for protected routes
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1] || req.cookies.token;
+  if (!token) return res.sendStatus(401);
+
+  jwt.verify(token, SECRET, (err, payload) => {
+    if (err) return res.sendStatus(403);
+    req.user = payload;
+    next();
+  });
+}
+
+// Profile endpoint uses authenticated user ID
+app.get('/api/profile', authenticateToken, (req, res) => {
+  const user = users.find(u => u.id === req.user.id);
+  if (!user) return res.sendStatus(404);
+  res.json(user.profile);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/src/components/student-portal.tsx
+++ b/src/components/student-portal.tsx
@@ -30,12 +30,27 @@ export function StudentPortal({ onNavigate }: StudentPortalProps) {
     status: 'allocated'
   };
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // "API_CALL: Authentication endpoint - POST /api/auth/student/login"
-    setIsLoggedIn(true);
-    // Check if user has profile from API response
-    setHasProfile(false); // Initially false to show profile creation
+    const formData = new FormData(e.currentTarget);
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
+
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: email, password })
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      setIsLoggedIn(true);
+      const profileRes = await fetch('/api/profile', {
+        headers: { Authorization: `Bearer ${data.token}` }
+      });
+      setHasProfile(profileRes.ok);
+    }
   };
 
   const handleRegister = (e: React.FormEvent) => {
@@ -118,25 +133,27 @@ export function StudentPortal({ onNavigate }: StudentPortalProps) {
                   <div className="space-y-4">
                     <div>
                       <Label htmlFor="email" className="text-gray-700">Email Address</Label>
-                      <Input 
-                        id="email" 
-                        type="email" 
-                        required 
+                      <Input
+                        id="email"
+                        name="email"
+                        type="email"
+                        required
                         className="mt-1 border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                         placeholder="student@university.edu"
                       />
                     </div>
                     <div>
                       <Label htmlFor="password" className="text-gray-700">Password</Label>
-                      <Input 
-                        id="password" 
-                        type="password" 
-                        required 
+                      <Input
+                        id="password"
+                        name="password"
+                        type="password"
+                        required
                         className="mt-1 border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                         placeholder="Enter your password"
                       />
-                    </div>
                   </div>
+                </div>
                   <Button type="submit" className="w-full bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white py-3 transition-all duration-300 transform hover:scale-105">
                     🚀 Login to Dashboard
                   </Button>


### PR DESCRIPTION
## Summary
- add Express server issuing JWTs and verifying them for protected routes
- update student login to store returned token and request profile
- declare authentication dependencies and server start script

## Testing
- `npm install express jsonwebtoken cookie-parser --registry=https://registry.npmjs.org` (fails: 403 Forbidden)
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5bef8ddc4833383f60662088cdf8f