### PR TITLE
feat: add internship and allocation APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-"node_modules/" 
+node_modules/

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
       },
       "scripts": {
           "dev": "vite",
-          "build": "vite build"
+          "build": "vite build",
+          "start": "node server.js"
       }
   }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,122 @@
+const http = require('http');
+const { parse } = require('url');
+
+let internships = [
+  {
+    id: 1,
+    title: 'Software Development Intern',
+    company: 'Tech Solutions India Pvt Ltd',
+    duration: '6 months',
+    stipend: '₹15,000/month',
+    skills: ['React', 'Node.js', 'MongoDB']
+  },
+  {
+    id: 2,
+    title: 'Data Analyst Intern',
+    company: 'Data Corp',
+    duration: '3 months',
+    stipend: '₹10,000/month',
+    skills: ['Python', 'SQL']
+  }
+];
+
+let allocations = [
+  { studentId: 1, internshipId: 1 }
+];
+
+let nextId = 3;
+
+function send(res, status, data) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(JSON.stringify(data));
+}
+
+function parseBody(req, cb) {
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    try {
+      cb(JSON.parse(body || '{}'));
+    } catch {
+      cb({});
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const { pathname, query } = parse(req.url, true);
+
+  if (req.method === 'OPTIONS') {
+    send(res, 200, {});
+    return;
+  }
+
+  if (pathname === '/api/internships' && req.method === 'GET') {
+    if (query.studentId) {
+      const sid = Number(query.studentId);
+      const ids = allocations.filter(a => a.studentId === sid).map(a => a.internshipId);
+      return send(res, 200, internships.filter(i => ids.includes(i.id)));
+    }
+    return send(res, 200, internships);
+  }
+
+  if (pathname === '/api/internships' && req.method === 'POST') {
+    return parseBody(req, body => {
+      const internship = { id: nextId++, ...body };
+      internships.push(internship);
+      send(res, 201, internship);
+    });
+  }
+
+  if (pathname.startsWith('/api/internships/') ) {
+    const id = Number(pathname.split('/')[3]);
+    const index = internships.findIndex(i => i.id === id);
+    if (index === -1) {
+      send(res, 404, { error: 'Internship not found' });
+      return;
+    }
+
+    if (req.method === 'GET') {
+      return send(res, 200, internships[index]);
+    }
+
+    if (req.method === 'PUT') {
+      return parseBody(req, body => {
+        internships[index] = { ...internships[index], ...body, id };
+        send(res, 200, internships[index]);
+      });
+    }
+
+    if (req.method === 'DELETE') {
+      const removed = internships.splice(index, 1)[0];
+      allocations = allocations.filter(a => a.internshipId !== id);
+      return send(res, 200, removed);
+    }
+  }
+
+  if (pathname === '/api/allocations' && req.method === 'GET') {
+    return send(res, 200, allocations);
+  }
+
+  if (pathname === '/api/allocations' && req.method === 'POST') {
+    return parseBody(req, body => {
+      const { studentId, internshipId } = body;
+      const exists = internships.some(i => i.id === internshipId);
+      if (!exists) return send(res, 404, { error: 'Internship not found' });
+      allocations = allocations.filter(a => !(a.studentId === studentId && a.internshipId === internshipId));
+      const alloc = { studentId, internshipId };
+      allocations.push(alloc);
+      send(res, 201, alloc);
+    });
+  }
+
+  send(res, 404, { error: 'Not found' });
+});
+
+const PORT = process.env.PORT || 4000;
+server.listen(PORT, () => console.log(`API server running on port ${PORT}`));

--- a/src/components/student-portal.tsx
+++ b/src/components/student-portal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Input } from './ui/input';
@@ -17,6 +17,16 @@ export function StudentPortal({ onNavigate }: StudentPortalProps) {
   const [hasProfile, setHasProfile] = useState(false);
   const [currentTab, setCurrentTab] = useState('login');
   const [hasInternship, setHasInternship] = useState(false);
+
+  const studentId = 1;
+  const [internships, setInternships] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`http://localhost:4000/api/internships?studentId=${studentId}`)
+      .then(res => res.json())
+      .then(setInternships)
+      .catch(() => setInternships([]));
+  }, []);
 
   // Mock internship data
   const mockInternship = {
@@ -342,52 +352,26 @@ export function StudentPortal({ onNavigate }: StudentPortalProps) {
                   <p className="text-gray-600">Browse and explore ongoing internship opportunities</p>
                 </CardHeader>
                 <CardContent>
-                  {/* Mock internship listings */}
                   <div className="space-y-4">
-                    <div className="border rounded-lg p-4 hover:shadow-md transition-shadow">
-                      <div className="flex justify-between items-start mb-2">
-                        <h3 className="font-semibold">Software Development Intern</h3>
-                        <Badge variant="secondary">Open</Badge>
+                    {internships.map((int) => (
+                      <div key={int.id} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
+                        <div className="flex justify-between items-start mb-2">
+                          <h3 className="font-semibold">{int.title}</h3>
+                          <Badge variant="secondary">Open</Badge>
+                        </div>
+                        <p className="text-gray-600 mb-2">{int.company}</p>
+                        <p className="text-sm text-gray-500 mb-3">Duration: {int.duration} | Stipend: {int.stipend}</p>
+                        <div className="flex gap-2 mb-3">
+                          {int.skills?.map((s: string) => (
+                            <Badge key={s} variant="outline">{s}</Badge>
+                          ))}
+                        </div>
+                        <Button size="sm">View Details</Button>
                       </div>
-                      <p className="text-gray-600 mb-2">Tech Solutions India Pvt Ltd</p>
-                      <p className="text-sm text-gray-500 mb-3">Duration: 6 months | Stipend: ₹15,000/month</p>
-                      <div className="flex gap-2 mb-3">
-                        <Badge variant="outline">React</Badge>
-                        <Badge variant="outline">Node.js</Badge>
-                        <Badge variant="outline">MongoDB</Badge>
-                      </div>
-                      <Button size="sm">View Details</Button>
-                    </div>
-
-                    <div className="border rounded-lg p-4 hover:shadow-md transition-shadow">
-                      <div className="flex justify-between items-start mb-2">
-                        <h3 className="font-semibold">Data Science Intern</h3>
-                        <Badge variant="secondary">Open</Badge>
-                      </div>
-                      <p className="text-gray-600 mb-2">Analytics Corp India</p>
-                      <p className="text-sm text-gray-500 mb-3">Duration: 4 months | Stipend: ₹12,000/month</p>
-                      <div className="flex gap-2 mb-3">
-                        <Badge variant="outline">Python</Badge>
-                        <Badge variant="outline">Machine Learning</Badge>
-                        <Badge variant="outline">SQL</Badge>
-                      </div>
-                      <Button size="sm">View Details</Button>
-                    </div>
-
-                    <div className="border rounded-lg p-4 hover:shadow-md transition-shadow">
-                      <div className="flex justify-between items-start mb-2">
-                        <h3 className="font-semibold">Digital Marketing Intern</h3>
-                        <Badge variant="secondary">Open</Badge>
-                      </div>
-                      <p className="text-gray-600 mb-2">Creative Marketing Solutions</p>
-                      <p className="text-sm text-gray-500 mb-3">Duration: 3 months | Stipend: ₹10,000/month</p>
-                      <div className="flex gap-2 mb-3">
-                        <Badge variant="outline">SEO</Badge>
-                        <Badge variant="outline">Social Media</Badge>
-                        <Badge variant="outline">Content Writing</Badge>
-                      </div>
-                      <Button size="sm">View Details</Button>
-                    </div>
+                    ))}
+                    {internships.length === 0 && (
+                      <p className="text-gray-600">No internships allocated.</p>
+                    )}
                   </div>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary
- add HTTP server with CRUD endpoints for internships and allocations
- load allocated internships for the logged-in student
- add npm start script for API server

## Testing
- `npm test` (fails: Missing script "test")
- `node server.js &` then `curl -s http://localhost:4000/api/internships?studentId=1 && echo`
- `curl -s -X POST http://localhost:4000/api/allocations -H 'Content-Type: application/json' -d '{"studentId":2,"internshipId":2}' && echo`
- `curl -s http://localhost:4000/api/internships?studentId=2 && echo`


------
https://chatgpt.com/codex/tasks/task_e_68c5befa25d483338f2d0eefe0185eb9